### PR TITLE
Contribution Guidelines and License Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,3 +184,13 @@ KAFKA_CFG_PROCESS_ROLES=controller,broker
 - Integrated Kafka messaging and gRPC for efficient communication.
 
 ---
+
+## 🧑‍💻 Contributing
+We welcome contributions!  
+Please read our [Contributing Guidelines](./CONTRIBUTING.md) before submitting a Pull Request.  
+Follow the coding standards, commit message conventions, and issue process described there.
+
+---
+
+## 📄 License
+This project is licensed under the terms of the [MIT License](./LICENSE).


### PR DESCRIPTION
## 📝 PR: Add Contribution Guidelines and License Section in README

### 📋 Description
The current `README.md` does not clearly highlight the **Contribution Guidelines** and **License** sections.  
Without these, new contributors may not know how to raise issues, open PRs, or follow coding conventions.  
Also, users may not immediately know which license the project uses — even though a `LICENSE` file exists.  

This PR adds both sections to make the README more **complete, contributor-friendly, and transparent**.

---

### 🎯 Acceptance Criteria
- [x] Added **"Contributing"** section in `README.md`
- [x] Added **"License"** section in `README.md`
- [x] Linked to:
  - [`CONTRIBUTING.md`](./CONTRIBUTING.md)
  - [`LICENSE`](./LICENSE)
- [x] Maintained consistent Markdown formatting

---

Close issue #15